### PR TITLE
Authentication support, configurable max packet size

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Examples:
 ## Config:
 For example config check the example.conf!
 
+`username`/`password` are not required. If you miss one of these fields the app will try to connect as an unauthenticated/guest client.
+
+`maxPacketSize` are not required. The default value is 4096.
+
 For working (and non working) pattern examples check the TopicParserSpec file,
  under the tests (or read the upper sections to understand them)!
 

--- a/example.conf
+++ b/example.conf
@@ -4,7 +4,8 @@
     "host": "127.0.0.1",
     "port": 1883,
     "username": "foo",
-    "password": "bar"
+    "password": "bar",
+    "maxPacketSize": 4096
   },
   "patterns": [
     {

--- a/example.conf
+++ b/example.conf
@@ -2,7 +2,9 @@
 {
   "mqtt": {
     "host": "127.0.0.1",
-    "port": 1883
+    "port": 1883,
+    "username": "foo",
+    "password": "bar"
   },
   "patterns": [
     {

--- a/src/main/scala/xyz/tg44/prometheus/Config.scala
+++ b/src/main/scala/xyz/tg44/prometheus/Config.scala
@@ -35,10 +35,10 @@ object Config {
 
   import spray.json.DefaultJsonProtocol._
   case class AppConfig(mqtt: MqttConfig, patterns: Seq[PatternConf])
-  case class MqttConfig(host: String, port: Int)
+  case class MqttConfig(host: String, port: Int, username: String, password: String)
   case class PatternConf(prefix: String, pattern: String)
 
   implicit val patternConfigFormat: RootJsonFormat[PatternConf] = jsonFormat2(PatternConf)
-  implicit val mqttConfigFormat: RootJsonFormat[MqttConfig] = jsonFormat2(MqttConfig)
+  implicit val mqttConfigFormat: RootJsonFormat[MqttConfig] = jsonFormat4(MqttConfig)
   implicit val appConfigFormat: RootJsonFormat[AppConfig] = jsonFormat2(AppConfig)
 }

--- a/src/main/scala/xyz/tg44/prometheus/Config.scala
+++ b/src/main/scala/xyz/tg44/prometheus/Config.scala
@@ -35,10 +35,10 @@ object Config {
 
   import spray.json.DefaultJsonProtocol._
   case class AppConfig(mqtt: MqttConfig, patterns: Seq[PatternConf])
-  case class MqttConfig(host: String, port: Int, username: String, password: String)
+  case class MqttConfig(host: String, port: Int, username: Option[String], password: Option[String], maxPacketSize: Option[Int])
   case class PatternConf(prefix: String, pattern: String)
 
   implicit val patternConfigFormat: RootJsonFormat[PatternConf] = jsonFormat2(PatternConf)
-  implicit val mqttConfigFormat: RootJsonFormat[MqttConfig] = jsonFormat4(MqttConfig)
+  implicit val mqttConfigFormat: RootJsonFormat[MqttConfig] = jsonFormat5(MqttConfig)
   implicit val appConfigFormat: RootJsonFormat[AppConfig] = jsonFormat2(AppConfig)
 }

--- a/src/main/scala/xyz/tg44/prometheus/Main.scala
+++ b/src/main/scala/xyz/tg44/prometheus/Main.scala
@@ -57,7 +57,12 @@ object Main extends App {
       .toMat(Sink.fromGraph(new PullableSink[String]()))(Keep.both).run
 
 
-  commands.offer(Command(Connect("prom-mqtt", ConnectFlags.CleanSession)))
+  private val connect: Connect =
+    if (appConf.mqtt.username != null)
+      Connect("prom-mqtt", ConnectFlags.CleanSession, appConf.mqtt.username, appConf.mqtt.password)
+    else
+      Connect("prom-mqtt", ConnectFlags.CleanSession)
+  commands.offer(Command(connect))
   appConf.patterns.foreach{ p =>
     val topicToConnect = PatternUtils.topicFromPattern(p.pattern)
     commands.offer(Command(Subscribe(topicToConnect)))

--- a/src/main/scala/xyz/tg44/prometheus/Main.scala
+++ b/src/main/scala/xyz/tg44/prometheus/Main.scala
@@ -33,8 +33,8 @@ object Main extends App {
   val pathResolver: String => Option[MetricMeta] = PatternUtils.metaBuilder(appConf.patterns)
 
   var mqttSessionSettings = MqttSessionSettings()
-  if (appConf.mqtt.maxPacketSize.isDefined)
-    mqttSessionSettings = mqttSessionSettings.withMaxPacketSize(appConf.mqtt.maxPacketSize.get)
+  appConf.mqtt.maxPacketSize.foreach(maxPacketSize =>
+    mqttSessionSettings = mqttSessionSettings.withMaxPacketSize(maxPacketSize))
 
   val session = ActorMqttClientSession(mqttSessionSettings)
   val connection = Tcp().outgoingConnection(appConf.mqtt.host, appConf.mqtt.port)


### PR DESCRIPTION
This PR adds authentication support and configurable max packet size (as mqtt-prometheus-message-exporter was regularly crashing with the default 4k). I am not too happy with the explicit Option.isPresent checks, but am not too familiar with Scala to figure out a better way that is more idiomatic.

The exporter silently exits when the credentials are wrong, but I think it already did so before for wrong connection details.

Closes #1.